### PR TITLE
Control kube-proxy deployment from pillar

### DIFF
--- a/k8s_salt/map.jinja
+++ b/k8s_salt/map.jinja
@@ -278,7 +278,9 @@
 {% do binaries.append('kube-controller-manager') %}
 {% endif %}
 {% if salt['pillar.get']('k8s_salt:roles:worker') %}
+{% if not k8s_salt['kube-proxy'].get('disabled', False) %}
 {% do binaries.append('kube-proxy') %}
+{% endif %}
 {% do binaries.append('kubelet') %}
 {% endif %}
 {% if salt['pillar.get']('k8s_salt:roles:admin') %}

--- a/k8s_salt/proxy.sls
+++ b/k8s_salt/proxy.sls
@@ -1,7 +1,7 @@
 {% from './map.jinja' import k8s_salt %}
 
 {% if ('hostname_fqdn' in k8s_salt) and ('ca_server' in k8s_salt) %}
-{% if salt['pillar.get']('k8s_salt:roles:worker') and k8s_salt['kube-proxy'].get('run', True) %}
+{% if salt['pillar.get']('k8s_salt:roles:worker') and not k8s_salt['kube-proxy'].get('disabled', False) %}
 
   {% set cluster = salt['pillar.get']('k8s_salt:cluster') %}
 # TODO: factor out private key into macro
@@ -71,5 +71,10 @@ run_kubeproxy_unit:
   - enable: True
   - watch:
     - module: reload_kubeproxy_service
+{% else %}
+Dont run kubeproxy:
+  service.dead:
+  - name: kube-proxy
+  - enable: False
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Since the Cilium CNI offers a replacement for kube-proxy, cluster operators may want to skip the installation of kube-proxy by explicitly setting the pillar k8s_salt:kube-proxy:disabled:True.