### PR TITLE
Allow users to opt-in to installing cilium

### DIFF
--- a/k8s_salt/cluster_manifests.sls
+++ b/k8s_salt/cluster_manifests.sls
@@ -13,8 +13,10 @@ Place cluster manifests:
   - names:
     - /etc/kubernetes/cluster-wide-manifests/coredns.yml:
       - source: salt://{{ slspath }}/cluster-wide-manifests/coredns.yml
+{% if k8s_salt['addons'].get('cilium', {}).get('enabled', False) %}
     - /etc/kubernetes/cluster-wide-manifests/cilium.yml:
       - source: salt://{{ slspath }}/cluster-wide-manifests/cilium.yml
+{% endif %}
     - /etc/kubernetes/cluster-wide-manifests/kubelet-access.yml:
       - source: salt://{{ slspath }}/cluster-wide-manifests/kubelet-access.yml
   cmd.run:

--- a/k8s_salt/map.jinja
+++ b/k8s_salt/map.jinja
@@ -242,6 +242,9 @@
   {% endif %}
 {% endfor %}
 
+{% set addons = salt['pillar.get']('k8s_salt').get('addons', {}) %}
+{% do k8s_salt.update({'addons':addons}) %}
+
 {% do k8s_salt.update({'arch':salt['pillar.get']('k8s_salt:arch') or salt['grains.get']('osarch') or 'amd64'}) %}
 {% do k8s_salt.update({'cas':['kube-ca','etcd-peer-ca','etcd-trusted-ca','requestheader-ca']}) %}
 


### PR DESCRIPTION
Since the recommended way of installing cilium is by helm chart and installing a CNI plugin in general is a separate concern, the manifests are included as a convenience measure. Users will be expected to explicitly enable cilium installation by setting the pillar k8s_salt:addons:cilium:enabled:True.