### PR TITLE
Assign node-role.kubernetes.io/<role>="" labels

### DIFF
--- a/k8s_salt/cluster-wide-manifests/node-roles.yml
+++ b/k8s_salt/cluster-wide-manifests/node-roles.yml
@@ -1,0 +1,105 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-salt
+  labels:
+    app.kubernetes.io/managed-by: k8s-salt
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-roles
+  namespace: k8s-salt
+  labels:
+    app.kubernetes.io/managed-by: k8s-salt
+    app.kubernetes.io/name: node-roles
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-roles
+  labels:
+    app.kubernetes.io/managed-by: k8s-salt
+    app.kubernetes.io/name: node-roles
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-roles
+  labels:
+    app.kubernetes.io/managed-by: k8s-salt
+    app.kubernetes.io/name: node-roles
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-roles
+subjects:
+- kind: ServiceAccount
+  name: node-roles
+  namespace: k8s-salt
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-roles
+  namespace: k8s-salt
+  labels:
+    app.kubernetes.io/managed-by: k8s-salt
+    app.kubernetes.io/name: node-roles
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: k8s-salt
+      app.kubernetes.io/name: node-roles
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: k8s-salt
+        app.kubernetes.io/name: node-roles
+    spec:
+      hostNetwork: true
+      serviceAccount: node-roles
+      serviceAccountName: node-roles
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/roles
+          type: DirectoryOrCreate
+        name: roles
+      containers:
+      - name: node-roles
+        image: curlimages/curl
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        command:
+        - sh
+        # TODO: template apiserver port
+        args:
+        - -c
+        - |-
+          while true ;
+          do 
+            curl https://127.0.0.1:6443/api/v1/nodes/${NODE_NAME} -XPATCH -sS --output /dev/null \
+              -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+              --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+              --data @/etc/kubernetes/roles/roles.json \
+              -H "Content-Type: application/merge-patch+json" ;
+            sleep 60 ;
+          done
+        volumeMounts:
+        - mountPath: /etc/kubernetes/roles
+          name: roles

--- a/k8s_salt/noderoles.sls
+++ b/k8s_salt/noderoles.sls
@@ -5,3 +5,19 @@ Create file with roles:
   - names:
     - /etc/kubernetes/roles/roles.json:
       - source: salt://{{ slspath }}/templates/roles.json
+
+{% if salt['pillar.get']('k8s_salt:roles:admin') %}
+Deploy node-role daemon:
+  file.managed:
+  - makedirs: True
+  - mode: '0644'
+  - names:
+    - /etc/kubernetes/cluster-wide-manifests/node-roles.yml:
+      - source: salt://{{ slspath }}/cluster-wide-manifests/node-roles.yml
+  cmd.run:
+  - names:
+    - '/usr/local/bin/kubectl --kubeconfig /etc/kubernetes/config/admin.kubeconfig apply -f /etc/kubernetes/cluster-wide-manifests/node-roles.yml'
+  - require:
+    - file: Deploy node-role daemon
+    - file: Create file with roles
+{% endif %}

--- a/k8s_salt/noderoles.sls
+++ b/k8s_salt/noderoles.sls
@@ -6,7 +6,7 @@ Create file with roles:
     - /etc/kubernetes/roles/roles.json:
       - source: salt://{{ slspath }}/templates/roles.json
 
-{% if salt['pillar.get']('k8s_salt:roles:admin') %}
+{% if salt['pillar.get']('k8s_salt:roles:admin') and salt['pillar.get']('k8s_salt:set_node_roles', True) %}
 Deploy node-role daemon:
   file.managed:
   - makedirs: True

--- a/k8s_salt/noderoles.sls
+++ b/k8s_salt/noderoles.sls
@@ -1,0 +1,7 @@
+Create file with roles:
+  file.managed:
+  - makedirs: True
+  - template: 'jinja'
+  - names:
+    - /etc/kubernetes/roles/roles.json:
+      - source: salt://{{ slspath }}/templates/roles.json

--- a/k8s_salt/templates/roles.json
+++ b/k8s_salt/templates/roles.json
@@ -1,0 +1,7 @@
+{# vi: set ft=sls : -#}
+{"metadata":{"labels":{
+{%- for k, v in pillar.k8s_salt.roles.items() -%}
+"node-role.kubernetes.io/{{ k }}":{% if v %}""{% else %}null{% endif %}
+{%- if not loop.last %},{% endif -%}
+{%- endfor -%}
+{{ "}}}" }}


### PR DESCRIPTION
This PR introduces a DaemonSet that is deployed to the cluster which curls to the apiserver to assign each node labels of the form
```
{% for k,v in k8s_salt.roles.items() %}
    node-role.kubernetes.io/{{ k }}: {% if v %}""{% else %}null{% endif %}
{% endfor %}
```
It is possible to opt out by setting `k8s_salt:set_node_roles:False`.