### PR TITLE
New repo for haproxy

### DIFF
--- a/k8s_salt/haproxy.sls
+++ b/k8s_salt/haproxy.sls
@@ -11,18 +11,18 @@ Noop if this is a controlplane node:
 {% if grains['os_family'] == 'Debian' %}
 add_haproxy_repo_key:
   cmd.run:
-    - name: wget -O - {{ k8s_salt['haproxy_proxy_repo'] }}/HAPROXY-key-community.asc | apt-key add -
-    - unless: apt-key list | grep 'HAProxy'
+    - name: wget -O - "{{ k8s_salt['haproxy_repo_key'] }}" | apt-key add -
+    - unless: apt-key list | grep -i 'haproxy'
 {% endif %}
 
 add_haproxy_repo:
 {% if grains['os_family'] == 'Debian' %}
   pkgrepo.managed:
     - humanname: HAProxy
-    - name: deb {{ k8s_salt['haproxy_proxy_repo'] }}/haproxy/{{ grains['os']|lower }}-{{ grains['oscodename']|lower }}/ {{ grains['oscodename']|lower }} main
+    - name: deb "{{ k8s_salt['haproxy_proxy_repo'] }}" {{ grains['oscodename']|lower }} main
     - dist: {{ grains['oscodename']|lower }}
     - gpgcheck: 1
-    - key_url: {{ k8s_salt['haproxy_proxy_repo'] }}/HAPROXY-key-community.asc
+    - key_url: "{{ k8s_salt['haproxy_repo_key'] }}"
     - require:
       - cmd: add_haproxy_repo_key
 {% else %}

--- a/k8s_salt/map.jinja
+++ b/k8s_salt/map.jinja
@@ -272,7 +272,8 @@
 {% do k8s_salt.update({'k8s_proxy_repo':salt['pillar.get']('k8s_salt:k8s_proxy_repo') or 'https://storage.googleapis.com/kubernetes-release/release'}) %}
 {% do k8s_salt.update({'etcd_proxy_repo':salt['pillar.get']('k8s_salt:etcd_proxy_repo') or 'https://github.com/etcd-io/etcd/releases/download'}) %}
 {% do k8s_salt.update({'cni_proxy_repo':salt['pillar.get']('k8s_salt:cni_proxy_repo') or 'https://github.com/containernetworking/plugins/releases/download'}) %}
-{% do k8s_salt.update({'haproxy_proxy_repo':salt['pillar.get']('k8s_salt:haproxy_proxy_repo') or 'https://www.haproxy.com/download/haproxy'}) %}
+{% do k8s_salt.update({'haproxy_proxy_repo':salt['pillar.get']('k8s_salt:haproxy_proxy_repo') or 'http://ppa.launchpad.net/vbernat/haproxy-2.4/ubuntu'}) %}
+{% do k8s_salt.update({'haproxy_repo_key':salt['pillar.get']('k8s_salt:haproxy_repo_key') or 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xcffb779aadc995e4f350a060505d97a41c61b9cd'}) %}
 
 # K8s binaries
 {% set binaries = [] %}


### PR DESCRIPTION
As haproxy has pulled the apt repo from its website, we're back to using Vincent Bernat's PPA from launchpad. PRs welcome to make this more flexible for a wider selection of OSs.